### PR TITLE
Prevent MooTools hasClass error on SVG or Polygon

### DIFF
--- a/src/scroller/scroller.js
+++ b/src/scroller/scroller.js
@@ -148,7 +148,7 @@ window.addEvent('domready', function(e) {
 			var target = touch.target;
 			var identifier = touch.identifier;
 
-			if (target === undefined || target.tagName === undefined || target.tagName.match(/input|textarea|select|a/i)) {
+			if (target === undefined || target.tagName === undefined || target.tagName.match(/input|textarea|select|a|svg|polygon/i)) {
 				scrolls[identifier] = false;
 				return;
 			}


### PR DESCRIPTION
Calling hasClass (for moobile-clickable, scrollable, etc.) on a SVG or Polygon tag is causing an error in MooTools core :
"this.className.clean is not a function at line 279" (mootools-core-1.4.5.min.js)